### PR TITLE
[WIP] use new `pennylane.exceptions` module rather than top-level import

### DIFF
--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -23,7 +23,7 @@ import itertools as it
 
 import numpy as np
 
-from pennylane import DeviceError, QuantumFunctionError
+from pennylane.exceptions import DeviceError, QuantumFunctionError
 from pennylane.devices import QubitDevice
 from pennylane.ops import (
     StatePrep,


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/7205 adds the new `exceptions` module.

**Description of the Change:**

Update to use that new module rather than top level imports.

**Benefits:** Should not depend on top-level imports.

**Possible Drawbacks:** None

[sc-88954]